### PR TITLE
Add Django template version of draft_text filter

### DIFF
--- a/decorators.py
+++ b/decorators.py
@@ -11,7 +11,7 @@ from wagtail.wagtailimages.formats import get_image_format
 from wagtail.wagtailimages.models import get_image_model
 from wagtail.wagtailimages.shortcuts import get_rendition_or_not_found
 
-from core.utilities import get_document_meta
+# from core.utilities import get_document_meta
 
 MISSING_RESOURCE_CLASS = 'link--missing-resource'
 MISSING_RESOURCE_URL = '#'

--- a/templatetags/draftail_tags.py
+++ b/templatetags/draftail_tags.py
@@ -1,0 +1,26 @@
+import json
+
+from django import template
+from django.utils.safestring import mark_safe
+from draftjs_exporter.html import HTML
+from wagtaildraftail.settings import get_exporter_config
+
+
+register = template.Library()
+
+
+class DraftValue:
+    def __init__(self, data):
+        self.data = data
+        self.exporter = HTML(get_exporter_config())
+
+    def __html__(self):
+        return self.exporter.render(self.data)
+
+
+@register.filter
+def draft_text(text):
+    data = json.loads(text)
+    node = DraftValue(data)
+
+    return mark_safe(node.__html__())


### PR DESCRIPTION
Usage:

    {% load draftail_tags %}
    
    {{ page.intro|draft_text }}

(Note: to get this working I've had to comment out `from core.utilities import get_document_meta` from decorators.py, as this module doesn't appear to exist within the project...)