### PR TITLE
Links

### DIFF
--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -4,8 +4,9 @@ import unittest
 
 from draftjs_exporter.constants import BLOCK_TYPES
 from draftjs_exporter.dom import DOM
-from home.models import HomePage
 from wagtail.wagtailcore.models import Page, Site
+
+from home.models import HomePage
 from wagtaildraftail.decorators import BR, HR, MISSING_RESOURCE_URL, Icon, Link
 
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -44,13 +44,13 @@ class TestLink(unittest.TestCase):
         self.page = page
 
     def test_internal_link(self):
-        """Test if the page URL and title are set."""
+        """Test if the page URL is set."""
         input_props = {
             'linkType': 'page',
             'id': self.page.pk
         }
         output = DOM.render(DOM.create_element(Link, input_props))
-        self.assertEqual(output, '<a href="{0}" title="{1}"></a>'.format(self.page.url, self.page.title))
+        self.assertEqual(output, '<a href="{0}"></a>'.format(self.page.url))
 
     def test_internal_link_href_fallback(self):
         """Test if the fallback href is used when the page does not exist."""
@@ -70,6 +70,16 @@ class TestLink(unittest.TestCase):
         output = DOM.render(DOM.create_element(Link, input_props))
         self.assertEqual(output, '<a href="http://test.test"></a>')
 
+    def test_with_title(self):
+        """Test if title attribute is set."""
+        input_props = {
+            'linkType': 'external',
+            'url': 'http://test.test',
+            'title': 'Test title'
+        }
+        output = DOM.render(DOM.create_element(Link, input_props))
+        self.assertEqual(output, '<a href="http://test.test" title="Test title"></a>')
+
     def test_with_children(self):
         """Test if child content is rendered."""
         input_props = {
@@ -77,4 +87,4 @@ class TestLink(unittest.TestCase):
             'id': self.page.pk,
         }
         output = DOM.render(DOM.create_element(Link, input_props, 'anchor content'))
-        self.assertEqual(output, '<a href="{0}" title="{1}">anchor content</a>'.format(self.page.url, self.page.title))
+        self.assertEqual(output, '<a href="{0}">anchor content</a>'.format(self.page.url))

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -4,7 +4,9 @@ import unittest
 
 from draftjs_exporter.constants import BLOCK_TYPES
 from draftjs_exporter.dom import DOM
-from wagtaildraftail.decorators import BR, HR, Icon
+from home.models import HomePage
+from wagtail.wagtailcore.models import Page, Site
+from wagtaildraftail.decorators import BR, HR, MISSING_RESOURCE_URL, Icon, Link
 
 
 class TestIcon(unittest.TestCase):
@@ -27,3 +29,51 @@ class TestBR(unittest.TestCase):
     def test_render_code_block(self):
         element = DOM.create_element(BR, {'block_type': BLOCK_TYPES.CODE}, '\n')
         self.assertEqual(element, '\n')
+
+
+class TestLink(unittest.TestCase):
+    """Tests several scenarios regarding rendering of a link."""
+
+    def setUp(self):
+        """Test."""
+        root_site = Site.objects.get(is_default_site=True)
+        root_page = Page.objects.get(id=root_site.root_page_id)
+        page = HomePage(title="Testpage")
+        root_page.add_child(instance=page)
+        self.page = page
+
+    def test_internal_link(self):
+        """Test if the page URL and title are set."""
+        input_props = {
+            'linkType': 'page',
+            'id': self.page.pk
+        }
+        output = DOM.render(DOM.create_element(Link, input_props))
+        self.assertEqual(output, '<a href="{0}" title="{1}"></a>'.format(self.page.url, self.page.title))
+
+    def test_internal_link_href_fallback(self):
+        """Test if the fallback href is used when the page does not exist."""
+        input_props = {
+            'linkType': 'page',
+            'id': 999,
+        }
+        output = DOM.render(DOM.create_element(Link, input_props))
+        self.assertEqual(output, '<a href="{0}"></a>'.format(MISSING_RESOURCE_URL))
+
+    def test_external_link(self):
+        """Test if external links are passed as such."""
+        input_props = {
+            'linkType': 'external',
+            'url': 'http://test.test',
+        }
+        output = DOM.render(DOM.create_element(Link, input_props))
+        self.assertEqual(output, '<a href="http://test.test"></a>')
+
+    def test_with_children(self):
+        """Test if child content is rendered."""
+        input_props = {
+            'linkType': 'page',
+            'id': self.page.pk,
+        }
+        output = DOM.render(DOM.create_element(Link, input_props, 'anchor content'))
+        self.assertEqual(output, '<a href="{0}" title="{1}">anchor content</a>'.format(self.page.url, self.page.title))

--- a/wagtaildraftail/decorators.py
+++ b/wagtaildraftail/decorators.py
@@ -25,21 +25,25 @@ def HR(props):
 
 class Link:
     def render(self, props):
-        data = props.get('data', {})
-
-        if 'id' in data:
+        link_type = props.get('linkType', '')
+        title = None
+        if link_type == 'page':
             try:
-                page = Page.objects.get(id=data['id'])
+                page_id = props.get('id')
+                page = Page.objects.get(id=page_id)
                 href = page.url
+                title = page.title
             except Page.DoesNotExist:
-                href = data.get('url', MISSING_RESOURCE_URL)
+                href = props.get('url', MISSING_RESOURCE_URL)
         else:
-            href = data.get('url', MISSING_RESOURCE_URL)
+            href = props.get('url', MISSING_RESOURCE_URL)
 
-        return DOM.create_element('a', {
-            'href': href,
-            'title': data.get('title'),
-        }, props['children'])
+        anchor_properties = {
+            'href': href
+        }
+        if title is not None:
+            anchor_properties['title'] = title
+        return DOM.create_element('a', anchor_properties, props['children'])
 
 
 class Model:

--- a/wagtaildraftail/decorators.py
+++ b/wagtaildraftail/decorators.py
@@ -26,13 +26,13 @@ def HR(props):
 class Link:
     def render(self, props):
         link_type = props.get('linkType', '')
-        title = None
+        title = props.get('title')
+
         if link_type == 'page':
             try:
                 page_id = props.get('id')
                 page = Page.objects.get(id=page_id)
                 href = page.url
-                title = page.title
             except Page.DoesNotExist:
                 href = props.get('url', MISSING_RESOURCE_URL)
         else:
@@ -41,8 +41,10 @@ class Link:
         anchor_properties = {
             'href': href
         }
+
         if title is not None:
             anchor_properties['title'] = title
+
         return DOM.create_element('a', anchor_properties, props['children'])
 
 


### PR DESCRIPTION
This fixes an issue where internal page links inserted with Draftail always pointed to `#`. 
I also added some unittests.