### PR TITLE
Call Make target with 'make' in front

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,7 @@
 help: ## See what commands are available.
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36mmake %-15s\033[0m # %s\n", $$1, $$2}'
 
-init: ## Install dependencies and initialise for development.
-	make clean-pyc
+init: clean-pyc ## Install dependencies and initialise for development.
 	pip install -e .[testing,docs] -U
 	nvm install || echo "nvm is not available"
 	npm install

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ help: ## See what commands are available.
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36mmake %-15s\033[0m # %s\n", $$1, $$2}'
 
 init: ## Install dependencies and initialise for development.
-	clean-pyc
+	make clean-pyc
 	pip install -e .[testing,docs] -U
 	nvm install || echo "nvm is not available"
 	npm install


### PR DESCRIPTION
I encountered this error while running `make init`:
```
(.venv)me:~/projects/wagtaildraftail$ make init
clean-pyc
make: clean-pyc: No such file or directory
make: *** [init] Error 1
```

Prepending `clean-pyc` with `make` solves the issue.