### PR TITLE
Configurable Custom Components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,6 @@ $virtualenv.tar.gz
 *.sql
 example.html
 static
+!tests/testapp/home/static/
 tests/testapp/var/media/
 db.sqlite3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## [Unreleased](https://github.com/springload/wagtaildraftail/compare/v0.4.1...HEAD)
 
+### Add
+
+- Hooks to register custom components.
+
+### Changed
+
 - Update to latest version of `draftjs_exporter`.
+
 
 ## [[v0.4.1]](https://github.com/springload/draftjs_exporter/releases/tag/v0.4.1)
 

--- a/README.rst
+++ b/README.rst
@@ -240,17 +240,17 @@ A ``page decorator`` is a simple Python class with a ``render`` method accepting
         def render(self, props):
             return DOM.parse_html(embed_to_frontend_html(props['url']))
 
-An ``editor decorator`` is a simple React component (usually stateless) to render the entity in the editor. The JS file will need to be loaded with the ``insert_editor_js`` `hook<http://docs.wagtail.io/en/v1.9.1/reference/hooks.html#insert-editor-js>`_ and the decorator registered with ``window.wagtaildraftail.registerDecorator``.
+An ``editor decorator`` is a simple React component (usually stateless) to render the entity in the editor. The JS file will need to be loaded with the ``insert_editor_js`` `hook<http://docs.wagtail.io/en/v1.9.1/reference/hooks.html#insert-editor-js>`_ and the decorator registered with ``window.wagtailDraftail.registerDecorator``.
 
 .. code:: javascript
 
     /* Without a build step */
     const ButtonDecorator = ({ entityKey, children }) => {
       const attrs = {'data-tooltip': entityKey, className: 'RichEditor-button'};
-      return window.wagtaildraftail.createElement('span', attrs, children);
+      return window.wagtailDraftail.createElement('span', attrs, children);
     };
 
-    window.wagtaildraftail.registerDecorator('ButtonDecorator', ButtonDecorator);
+    window.wagtailDraftail.registerDecorator('ButtonDecorator', ButtonDecorator);
 
     /* With a build step for more complex elements */
     import React from 'react';
@@ -274,7 +274,7 @@ An ``editor decorator`` is a simple React component (usually stateless) to rende
     };
 
     // Or `export default Link;` and register later.
-    window.wagtaildraftail.registerDecorator('Link', Link);
+    window.wagtailDraftail.registerDecorator('Link', Link);
 
     /* More examples at https://github.com/springload/wagtaildraftail/tree/master/wagtaildraftail/client/decorators */
 
@@ -287,7 +287,7 @@ An ``editor source`` is usually more complex and will usually show a modal for t
     class LinkSource extends React.Component { ... }
 
     // Or `export default LinkSource;` and register later.
-    window.wagtaildraftail.registerSource('LinkSource', LinkSource);
+    window.wagtailDraftail.registerSource('LinkSource', LinkSource);
 
     /* More examples at https://github.com/springload/wagtaildraftail/tree/master/wagtaildraftail/client/sources */
 

--- a/tests/testapp/home/decorators.py
+++ b/tests/testapp/home/decorators.py
@@ -23,7 +23,7 @@ class Button:
 
         anchor_properties = {
             'className': 'button',
-            'onclick': "window.location.href='{}'".format(href),
+            'href': href,
         }
 
-        return DOM.create_element('button', anchor_properties, props['children'])
+        return DOM.create_element('a', anchor_properties, props['children'])

--- a/tests/testapp/home/decorators.py
+++ b/tests/testapp/home/decorators.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from draftjs_exporter.dom import DOM
 from wagtail.wagtailcore.models import Page
 

--- a/tests/testapp/home/decorators.py
+++ b/tests/testapp/home/decorators.py
@@ -1,0 +1,27 @@
+from draftjs_exporter.dom import DOM
+from wagtail.wagtailcore.models import Page
+
+MISSING_RESOURCE_CLASS = 'button--missing-resource'
+MISSING_RESOURCE_URL = '#'
+
+
+class Button:
+    def render(self, props):
+        link_type = props.get('linkType', '')
+
+        if link_type == 'page':
+            try:
+                page_id = props.get('id')
+                page = Page.objects.get(id=page_id)
+                href = page.url
+            except Page.DoesNotExist:
+                href = props.get('url', MISSING_RESOURCE_URL)
+        else:
+            href = props.get('url', MISSING_RESOURCE_URL)
+
+        anchor_properties = {
+            'className': 'button',
+            'onclick': "window.location.href='{}'".format(href),
+        }
+
+        return DOM.create_element('button', anchor_properties, props['children'])

--- a/tests/testapp/home/static/button_entity.css
+++ b/tests/testapp/home/static/button_entity.css
@@ -1,0 +1,6 @@
+.RichEditor-button {
+    background: #fffadb;
+    border-bottom: 1px dotted #b16000;
+    padding: 0 2px;
+    cursor: pointer;
+}

--- a/tests/testapp/home/static/button_entity.js
+++ b/tests/testapp/home/static/button_entity.js
@@ -1,0 +1,6 @@
+const ButtonDecorator = ({ entityKey, children }) => {
+  const attrs = {'data-tooltip': entityKey, className: 'RichEditor-button'};
+  return window.wagtaildraftail.createElement('span', attrs, children);
+};
+
+window.wagtaildraftail.registerDecorator('ButtonDecorator', ButtonDecorator);

--- a/tests/testapp/home/static/button_entity.js
+++ b/tests/testapp/home/static/button_entity.js
@@ -1,6 +1,6 @@
 const ButtonDecorator = ({ entityKey, children }) => {
   const attrs = {'data-tooltip': entityKey, className: 'RichEditor-button'};
-  return window.wagtaildraftail.createElement('span', attrs, children);
+  return window.wagtailDraftail.createElement('span', attrs, children);
 };
 
-window.wagtaildraftail.registerDecorator('ButtonDecorator', ButtonDecorator);
+window.wagtailDraftail.registerDecorator('ButtonDecorator', ButtonDecorator);

--- a/tests/testapp/home/static/button_entity.js
+++ b/tests/testapp/home/static/button_entity.js
@@ -3,4 +3,4 @@ const ButtonDecorator = ({ entityKey, children }) => {
   return window.wagtailDraftail.createElement('span', attrs, children);
 };
 
-window.wagtailDraftail.registerDecorator('ButtonDecorator', ButtonDecorator);
+window.wagtailDraftail.registerDecorators({ ButtonDecorator });

--- a/tests/testapp/home/wagtail_hooks.py
+++ b/tests/testapp/home/wagtail_hooks.py
@@ -1,0 +1,20 @@
+from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.utils.html import format_html
+
+from wagtail.wagtailcore import hooks
+
+
+@hooks.register('insert_editor_js')
+def button_entity_js():
+    return format_html(
+        '<script src="{}"></script>',
+        static('button_entity.js')
+    )
+
+
+@hooks.register('insert_editor_css')
+def button_entity_css():
+    return format_html(
+        '<link rel="stylesheet" href="{}">',
+        static('button_entity.css')
+    )

--- a/tests/testapp/home/wagtail_hooks.py
+++ b/tests/testapp/home/wagtail_hooks.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.utils.html import format_html
-
 from wagtail.wagtailcore import hooks
 
 

--- a/tests/testapp/testapp/grains/rich_text.py
+++ b/tests/testapp/testapp/grains/rich_text.py
@@ -47,6 +47,13 @@ DRAFT_ENTITY_TYPE_DOCUMENT = {
     'source': 'DocumentSource',
     'decorator': 'Document',
 }
+DRAFT_ENTITY_TYPE_BUTTON = {
+    'label': 'Button',
+    'type': 'BUTTON',
+    'icon': 'icon-link',
+    'source': 'LinkSource',
+    'decorator': 'ButtonDecorator',
+}
 
 WAGTAILADMIN_RICH_TEXT_EDITORS = {
     'simple': {
@@ -80,6 +87,7 @@ WAGTAILADMIN_RICH_TEXT_EDITORS = {
                 DRAFT_ENTITY_TYPE_EMBED,
                 DRAFT_ENTITY_TYPE_LINK,
                 DRAFT_ENTITY_TYPE_DOCUMENT,
+                DRAFT_ENTITY_TYPE_BUTTON,
             ],
             'blockTypes': [
                 DRAFT_BLOCK_TYPE_H3,
@@ -111,6 +119,7 @@ DRAFT_EXPORTER_ENTITY_DECORATORS = {
     ENTITY_TYPES.IMAGE: 'wagtaildraftail.decorators.Image',
     ENTITY_TYPES.EMBED: 'wagtaildraftail.decorators.Embed',
     ENTITY_TYPES.HORIZONTAL_RULE: 'wagtaildraftail.decorators.HR',
+    'BUTTON': 'home.decorators.Button',
 }
 
 DRAFT_EXPORTER_COMPOSITE_DECORATORS = [

--- a/tests/testapp/testapp/grains/rich_text.py
+++ b/tests/testapp/testapp/grains/rich_text.py
@@ -47,9 +47,10 @@ DRAFT_ENTITY_TYPE_DOCUMENT = {
     'source': 'DocumentSource',
     'decorator': 'Document',
 }
+BUTTON_ENTITY_ID = 'BUTTON'
 DRAFT_ENTITY_TYPE_BUTTON = {
     'label': 'Button',
-    'type': 'BUTTON',
+    'type': BUTTON_ENTITY_ID,
     'icon': 'icon-link',
     'source': 'LinkSource',
     'decorator': 'ButtonDecorator',
@@ -119,7 +120,7 @@ DRAFT_EXPORTER_ENTITY_DECORATORS = {
     ENTITY_TYPES.IMAGE: 'wagtaildraftail.decorators.Image',
     ENTITY_TYPES.EMBED: 'wagtaildraftail.decorators.Embed',
     ENTITY_TYPES.HORIZONTAL_RULE: 'wagtaildraftail.decorators.HR',
-    'BUTTON': 'home.decorators.Button',
+    BUTTON_ENTITY_ID: 'home.decorators.Button',
 }
 
 DRAFT_EXPORTER_COMPOSITE_DECORATORS = [

--- a/tests/testapp/testapp/settings.py
+++ b/tests/testapp/testapp/settings.py
@@ -16,8 +16,6 @@ BASE_DIR = os.path.dirname(PROJECT_DIR)
 # Application definition
 
 INSTALLED_APPS = [
-    'home',
-
     'wagtaildraftail',
 
     'wagtail.wagtailforms',
@@ -41,6 +39,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+
+    'home',
 ]
 
 MIDDLEWARE = [

--- a/wagtaildraftail/client/registry.js
+++ b/wagtaildraftail/client/registry.js
@@ -1,35 +1,26 @@
-const _registry = {
+const registry = {
   decorators: {},
   sources: {},
   strategies: {},
 };
 
 const registerDecorator = (name, decorator) => {
-  _registry.decorators[name] = decorator;
-  console.log('decorator: ' + name);
+  registry.decorators[name] = decorator;
 };
 
-const getDecorator = (name) => {
-  return _registry.decorators[name];
-};
+const getDecorator = name => registry.decorators[name];
 
 const registerSource = (name, source) => {
-  _registry.sources[name] = source;
-  console.log('source: ' + name);
+  registry.sources[name] = source;
 };
 
-const getSource = (name) => {
-  return _registry.sources[name];
-};
+const getSource = name => registry.sources[name];
 
 const registerStrategy = (name, strategy) => {
-  _registry.strategies[name] = strategy;
-  console.log('strategy: ' + name);
+  registry.strategies[name] = strategy;
 };
 
-const getStrategy = (name) => {
-  return _registry.strategies[name];
-};
+const getStrategy = name => registry.strategies[name];
 
 export {
   registerDecorator,

--- a/wagtaildraftail/client/registry.js
+++ b/wagtaildraftail/client/registry.js
@@ -1,0 +1,41 @@
+const _registry = {
+  decorators: {},
+  sources: {},
+  strategies: {},
+};
+
+const registerDecorator = (name, decorator) => {
+  _registry.decorators[name] = decorator;
+  console.log('decorator: ' + name);
+};
+
+const getDecorator = (name) => {
+  return _registry.decorators[name];
+};
+
+const registerSource = (name, source) => {
+  _registry.sources[name] = source;
+  console.log('source: ' + name);
+};
+
+const getSource = (name) => {
+  return _registry.sources[name];
+};
+
+const registerStrategy = (name, strategy) => {
+  _registry.strategies[name] = strategy;
+  console.log('strategy: ' + name);
+};
+
+const getStrategy = (name) => {
+  return _registry.strategies[name];
+};
+
+export {
+  registerDecorator,
+  getDecorator,
+  registerSource,
+  getSource,
+  registerStrategy,
+  getStrategy,
+}

--- a/wagtaildraftail/client/registry.js
+++ b/wagtaildraftail/client/registry.js
@@ -4,29 +4,29 @@ const registry = {
   strategies: {},
 };
 
-const registerDecorator = (name, decorator) => {
-  registry.decorators[name] = decorator;
+const registerDecorators = (decorators) => {
+  Object.assign(registry.decorators, decorators);
 };
 
 const getDecorator = name => registry.decorators[name];
 
-const registerSource = (name, source) => {
-  registry.sources[name] = source;
+const registerSources = (sources) => {
+  Object.assign(registry.sources, sources);
 };
 
 const getSource = name => registry.sources[name];
 
-const registerStrategy = (name, strategy) => {
-  registry.strategies[name] = strategy;
+const registerStrategies = (strategies) => {
+  Object.assign(registry.strategies, strategies);
 };
 
 const getStrategy = name => registry.strategies[name];
 
 export {
-  registerDecorator,
+  registerDecorators,
   getDecorator,
-  registerSource,
+  registerSources,
   getSource,
-  registerStrategy,
+  registerStrategies,
   getStrategy,
 }

--- a/wagtaildraftail/client/registry.js
+++ b/wagtaildraftail/client/registry.js
@@ -22,11 +22,11 @@ const registerStrategies = (strategies) => {
 
 const getStrategy = name => registry.strategies[name];
 
-export {
+export default {
   registerDecorators,
   getDecorator,
   registerSources,
   getSource,
   registerStrategies,
   getStrategy,
-}
+};

--- a/wagtaildraftail/client/wagtaildraftail.js
+++ b/wagtaildraftail/client/wagtaildraftail.js
@@ -32,7 +32,6 @@ const getDefaultStrategy = (entityType) => {
 };
 
 const initDraftailEditor = (fieldName, options = {}) => {
-  console.log('initDraftailEditor');
   const field = document.querySelector(`[name="${fieldName}"]`);
   const editorWrapper = document.createElement('div');
   field.parentNode.appendChild(editorWrapper);

--- a/wagtaildraftail/client/wagtaildraftail.js
+++ b/wagtaildraftail/client/wagtaildraftail.js
@@ -8,7 +8,7 @@ import './wagtaildraftail.css';
 
 import decorators from './decorators';
 import sources from './sources';
-import {registerDecorator, getDecorator, registerSource, getSource, getStrategy} from './registry';
+import {registerDecorator, getDecorator, registerSource, getSource, registerStrategy, getStrategy} from './registry';
 
 // Register Decorators, Sources and Strategies
 Object.keys(decorators).forEach(function(key) {
@@ -63,5 +63,19 @@ const initDraftailEditor = (fieldName, options = {}) => {
 };
 
 window.initDraftailEditor = initDraftailEditor;
+
+window.wagtaildraftail = {
+  // Expose registry methods
+  registerDecorator: registerDecorator,
+  getDecorator: getDecorator,
+  registerSource: registerSource,
+  getSource: getSource,
+  registerStrategy: registerStrategy,
+  getStrategy: getStrategy,
+
+  // Expose basic React methods for basic needs
+  createClass: React.createClass,
+  createElement: React.createElement,
+};
 
 export default initDraftailEditor;

--- a/wagtaildraftail/client/wagtaildraftail.js
+++ b/wagtaildraftail/client/wagtaildraftail.js
@@ -6,11 +6,20 @@ import DraftailEditor from 'draftail';
 import 'draftail/dist/draftail.css';
 import './wagtaildraftail.css';
 
-import sources from './sources';
 import decorators from './decorators';
+import sources from './sources';
+import {registerDecorator, getDecorator, registerSource, getSource, getStrategy} from './registry';
+
+// Register Decorators, Sources and Strategies
+Object.keys(decorators).forEach(function(key) {
+  registerDecorator(key, decorators[key]);
+});
+Object.keys(sources).forEach(function(key) {
+  registerSource(key, sources[key]);
+});
 
 // TODO: Use the one from draftail once implemented https://github.com/springload/draftail/issues/48
-const getEntityStrategy = (entityType) => {
+const getDefaultStrategy = (entityType) => {
   return (contentBlock, callback) => {
     contentBlock.findEntityRanges((character) => {
       const entityKey = character.getEntity();
@@ -23,6 +32,7 @@ const getEntityStrategy = (entityType) => {
 };
 
 const initDraftailEditor = (fieldName, options = {}) => {
+  console.log('initDraftailEditor');
   const field = document.querySelector(`[name="${fieldName}"]`);
   const editorWrapper = document.createElement('div');
   field.parentNode.appendChild(editorWrapper);
@@ -35,9 +45,9 @@ const initDraftailEditor = (fieldName, options = {}) => {
     // eslint-disable-next-line no-param-reassign
     options.entityTypes = options.entityTypes.map(entity => Object.assign(entity, {
       // TODO: Rename keys accordingly once changed in draftail https://github.com/springload/draftail/issues/49
-      control: sources[entity.source],
-      strategy: getEntityStrategy(entity.type),
-      component: decorators[entity.decorator],
+      control: getSource(entity.source),
+      strategy: getStrategy(entity.type) || getDefaultStrategy(entity.type),
+      component: getDecorator(entity.decorator),
     }));
   }
 

--- a/wagtaildraftail/client/wagtaildraftail.js
+++ b/wagtaildraftail/client/wagtaildraftail.js
@@ -57,9 +57,8 @@ const initDraftailEditor = (fieldName, options = {}) => {
   ReactDOM.render(editor, editorWrapper);
 };
 
-window.initDraftailEditor = initDraftailEditor;
-
 window.wagtailDraftail = {};
+window.wagtailDraftail.initEditor = initDraftailEditor;
 Object.assign(window.wagtailDraftail, registry);
 
 // Expose basic React methods for basic needs

--- a/wagtaildraftail/client/wagtaildraftail.js
+++ b/wagtaildraftail/client/wagtaildraftail.js
@@ -8,11 +8,11 @@ import './wagtaildraftail.css';
 
 import decorators from './decorators';
 import sources from './sources';
-import {registerDecorators, getDecorator, registerSources, getSource, registerStrategies, getStrategy} from './registry';
+import registry from './registry';
 
-// Register Decorators, Sources and Strategies
-registerDecorators(decorators);
-registerSources(sources);
+// Register default Decorators and Sources
+registry.registerDecorators(decorators);
+registry.registerSources(sources);
 
 // TODO: Use the one from draftail once implemented https://github.com/springload/draftail/issues/48
 const getDefaultStrategy = (entityType) => {
@@ -40,9 +40,9 @@ const initDraftailEditor = (fieldName, options = {}) => {
     // eslint-disable-next-line no-param-reassign
     options.entityTypes = options.entityTypes.map(entity => Object.assign(entity, {
       // TODO: Rename keys accordingly once changed in draftail https://github.com/springload/draftail/issues/49
-      control: getSource(entity.source),
-      strategy: getStrategy(entity.type) || getDefaultStrategy(entity.type),
-      component: getDecorator(entity.decorator),
+      control: registry.getSource(entity.source),
+      strategy: registry.getStrategy(entity.type) || getDefaultStrategy(entity.type),
+      component: registry.getDecorator(entity.decorator),
     }));
   }
 
@@ -59,18 +59,11 @@ const initDraftailEditor = (fieldName, options = {}) => {
 
 window.initDraftailEditor = initDraftailEditor;
 
-window.wagtailDraftail = {
-  // Expose registry methods
-  registerDecorators: registerDecorators,
-  getDecorator: getDecorator,
-  registerSources: registerSources,
-  getSource: getSource,
-  registerStrategies: registerStrategies,
-  getStrategy: getStrategy,
+window.wagtailDraftail = {};
+Object.assign(window.wagtailDraftail, registry);
 
-  // Expose basic React methods for basic needs
-  createClass: React.createClass,
-  createElement: React.createElement,
-};
+// Expose basic React methods for basic needs
+window.wagtailDraftail.createClass = React.createClass;
+window.wagtailDraftail.createElement = React.createElement;
 
 export default initDraftailEditor;

--- a/wagtaildraftail/client/wagtaildraftail.js
+++ b/wagtaildraftail/client/wagtaildraftail.js
@@ -8,15 +8,11 @@ import './wagtaildraftail.css';
 
 import decorators from './decorators';
 import sources from './sources';
-import {registerDecorator, getDecorator, registerSource, getSource, registerStrategy, getStrategy} from './registry';
+import {registerDecorators, getDecorator, registerSources, getSource, registerStrategies, getStrategy} from './registry';
 
 // Register Decorators, Sources and Strategies
-Object.keys(decorators).forEach(function(key) {
-  registerDecorator(key, decorators[key]);
-});
-Object.keys(sources).forEach(function(key) {
-  registerSource(key, sources[key]);
-});
+registerDecorators(decorators);
+registerSources(sources);
 
 // TODO: Use the one from draftail once implemented https://github.com/springload/draftail/issues/48
 const getDefaultStrategy = (entityType) => {
@@ -65,11 +61,11 @@ window.initDraftailEditor = initDraftailEditor;
 
 window.wagtailDraftail = {
   // Expose registry methods
-  registerDecorator: registerDecorator,
+  registerDecorators: registerDecorators,
   getDecorator: getDecorator,
-  registerSource: registerSource,
+  registerSources: registerSources,
   getSource: getSource,
-  registerStrategy: registerStrategy,
+  registerStrategies: registerStrategies,
   getStrategy: getStrategy,
 
   // Expose basic React methods for basic needs

--- a/wagtaildraftail/client/wagtaildraftail.js
+++ b/wagtaildraftail/client/wagtaildraftail.js
@@ -64,7 +64,7 @@ const initDraftailEditor = (fieldName, options = {}) => {
 
 window.initDraftailEditor = initDraftailEditor;
 
-window.wagtaildraftail = {
+window.wagtailDraftail = {
   // Expose registry methods
   registerDecorator: registerDecorator,
   getDecorator: getDecorator,

--- a/wagtaildraftail/client/wagtaildraftail.test.js
+++ b/wagtaildraftail/client/wagtaildraftail.test.js
@@ -6,7 +6,7 @@ describe('wagtaildraftail', () => {
   });
 
   it('is exposed as global', () => {
-    expect(window.initDraftailEditor).toBe(initDraftailEditor);
+    expect(window.wagtailDraftail.initEditor).toBe(initDraftailEditor);
   });
 
   it('initialises the editor', () => {

--- a/wagtaildraftail/widgets.py
+++ b/wagtaildraftail/widgets.py
@@ -59,7 +59,7 @@ class DraftailTextArea(WidgetWithScript, forms.HiddenInput):
         return super(DraftailTextArea, self).render(name, encoded_value, attrs)
 
     def render_js_init(self, id_, name, value):
-        return "window.initDraftailEditor('{name}', {opts})".format(
+        return "window.wagtailDraftail.initEditor('{name}', {opts})".format(
             name=name, opts=json.dumps(self.options))
 
     def value_from_datadict(self, data, files, name):


### PR DESCRIPTION
Ref #9.

Inspired from `netlify-cms`, both for the registry and for exposing React functions.

It could use a bit more documentation on how to create an entity source, but I wonder if this should be a link to `springload/draftail` documentation (which does not exists FWIW) rather that on this project.

Also, previous discussion mentioned also publishing `wagtaildraftail` as a npm package for users who have their own build step and want to go deeper.
However, the only thing that felt missing was the `ModalSource` which is a wrapper around Wagtail's jQuery chooser modals.
Sure it would also be cool to have the registry available as a normal function, but it's available globally now so not essential.
In other words, I think it would be a nice to have, not a must have.