### PR TITLE
Implement Wagtail 1.12 'features' lists

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,14 @@ First, add a Draftail field to some of your pages. Here is an example:
             FieldPanel('body')
         ]
 
+When using Wagtail 1.12 and above, ``DraftailTextField`` accepts the keyword argument ``features`` to define the set of features available in the editor - see `Limiting features in a rich text field <http://docs.wagtail.io/en/v1.12.2/advanced_topics/customisation/page_editing_interface.html#limiting-features-in-a-rich-text-field>`_:
+
+.. code:: python
+
+    class MyPage(Page):
+        body = DraftailTextField(blank=True, features=['h2', 'h3', 'ul', 'ol', 'link', 'document-link'])
+
+
 Outputting the field directly onto a template will give the HTML representation; there is no need to use the ``richtext`` filter.
 
 .. code:: html
@@ -62,6 +70,13 @@ Here is an example using the ready-made block:
     class MyStructBlock(StructBlock):
         body = DraftailTextBlock()
 
+The ``features`` argument is supported when using Wagtail 1.12 and above:
+
+.. code:: python
+
+    class MyStructBlock(StructBlock):
+        body = DraftailTextBlock(features=['bold', 'italic', 'link', 'document-link'])
+
 Configuration
 ~~~~~~~~~~~~~
 
@@ -74,13 +89,69 @@ Each editor defined in ``WAGTAILADMIN_RICH_TEXT_EDITORS`` is a dictionary with 2
 -  ``WIDGET`` is a mandatory string set to the widget to use
    -  should always be set to ``wagtaildraftail.widgets.DraftailTextArea`` (or a subclass of it) to work with Draft.js content
 -  ``OPTIONS`` is a dictionary which follows the format of `Draftail configuration options <https://github.com/springload/draftail#usage>`_.
-   -  Draftail options which are JavaScript values are hydrated at runtime in ``client/wagtaildraftail.js``
+   -  Draftail options which are JavaScript values are hydrated at runtime in ``client/wagtaildraftail.js``. Alternatively, on Wagtail 1.12 and above, a ``features`` list can be passed within the ``OPTIONS`` dict in place of a full Draftail configuration.
 
 **WARNING:** The ``type`` key for ``blockTypes``, ``inlineStyles`` and ``entityTypes`` shouldn’t be changed. It is what defines how content is rendered, and is saved as a JSON blob in the database which would make migrations really painful.
 
 **WARNING:** All the blocks/styles/entities defined in the editor config should have been configured to render properly in the `exporter config <#exporter-configuration>`_.
 
 Here is a sample configuration file. This should live in your Django settings.
+
+For Wagtail 1.12.x and above:
+
+.. code:: python
+
+    from draftjs_exporter.constants import BLOCK_TYPES, ENTITY_TYPES
+    from draftjs_exporter.defaults import BLOCK_MAP
+
+    WAGTAILADMIN_RICH_TEXT_EDITORS = {
+        'default_draftail': {
+            'WIDGET': 'wagtaildraftail.widgets.DraftailTextArea',
+        },
+
+        'format_and_link': {
+            'WIDGET': 'wagtaildraftail.widgets.DraftailTextArea',
+            'OPTIONS': {
+                'features': ['link', 'bold', 'italic'],
+            }
+        },
+
+        # Wagtail dependencies
+        'default': {
+            'WIDGET': 'wagtail.wagtailadmin.rich_text.HalloRichTextArea'
+        },
+
+        'custom': {
+            'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
+        },
+    }
+
+    DRAFT_EXPORTER_ENTITY_DECORATORS = {
+        ENTITY_TYPES.LINK: 'wagtaildraftail.decorators.Link',
+        ENTITY_TYPES.DOCUMENT: 'wagtaildraftail.decorators.Document',
+        ENTITY_TYPES.IMAGE: 'wagtaildraftail.decorators.Image',
+        ENTITY_TYPES.EMBED: 'wagtaildraftail.decorators.Embed',
+        ENTITY_TYPES.HORIZONTAL_RULE: 'wagtaildraftail.decorators.HR',
+    }
+
+    DRAFT_EXPORTER_COMPOSITE_DECORATORS = [
+        'wagtaildraftail.decorators.BR',
+    ]
+
+    DRAFT_EXPORTER_BLOCK_MAP = dict(BLOCK_MAP, **{
+        BLOCK_TYPES.UNORDERED_LIST_ITEM: {
+            'element': 'li',
+            'wrapper': 'ul',
+            'wrapper_props': {'class': 'list-styled'},
+        },
+        BLOCK_TYPES.ORDERED_LIST_ITEM: {
+            'element': 'li',
+            'wrapper': 'ol',
+            'wrapper_props': {'class': 'list-numbered'},
+        },
+    })
+
+For Wagtail 1.11.x and below:
 
 .. code:: python
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -2,10 +2,12 @@ from __future__ import absolute_import, unicode_literals
 
 import json
 import re
+import unittest
 
 from bs4 import BeautifulSoup
 from django.test import SimpleTestCase
 from draftjs_exporter.constants import BLOCK_TYPES, ENTITY_TYPES
+from wagtail import VERSION as WAGTAIL_VERSION
 
 from wagtaildraftail.widgets import DraftailTextArea
 
@@ -68,6 +70,7 @@ class DraftailTextAreaWidgetTestCase(SimpleTestCase):
         options = self.extract_options_from_script(soup.script.text)
         self.assertDictEqual(options, CUSTOM_OPTIONS)
 
+    @unittest.skipIf(WAGTAIL_VERSION < (1, 12), "Rich text features are only supported on Wagtail 1.12 and above")
     def test_rendering_with_default_features(self):
         """
         When no options or features are specified for the widget,
@@ -98,6 +101,7 @@ class DraftailTextAreaWidgetTestCase(SimpleTestCase):
         self.assertTrue([entity for entity in options['entityTypes'] if entity['type'] == ENTITY_TYPES.LINK])
         self.assertTrue([entity for entity in options['entityTypes'] if entity['type'] == ENTITY_TYPES.IMAGE])
 
+    @unittest.skipIf(WAGTAIL_VERSION < (1, 12), "Rich text features are only supported on Wagtail 1.12 and above")
     def test_rendering_with_explicit_features(self):
         """
         A features list passed to the widget should generate an options dict for those

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -108,7 +108,7 @@ class DraftailTextAreaWidgetTestCase(SimpleTestCase):
         features (overriding any options dict that was passed)
         """
 
-        widget = DraftailTextArea(options=CUSTOM_OPTIONS, features=['h1', 'image'])
+        widget = DraftailTextArea(options=CUSTOM_OPTIONS, features=['h1', 'image', 'unknownfeature'])
 
         html = widget.render('default_editor', json.dumps({'key': 'val'}), {'id': 'id'})
         soup = BeautifulSoup(html, 'html.parser')

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import json
+import unittest
 
 from bs4 import BeautifulSoup
 from django.test import SimpleTestCase
@@ -9,6 +10,7 @@ from wagtaildraftail.widgets import DraftailTextArea
 
 
 class DraftailTextAreaWidgetTestCase(SimpleTestCase):
+    @unittest.expectedFailure
     def test_rendering(self):
         widget = DraftailTextArea()
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,18 +1,49 @@
 from __future__ import absolute_import, unicode_literals
 
 import json
-import unittest
+import re
 
 from bs4 import BeautifulSoup
 from django.test import SimpleTestCase
+from draftjs_exporter.constants import BLOCK_TYPES, ENTITY_TYPES
 
 from wagtaildraftail.widgets import DraftailTextArea
 
 
+CUSTOM_OPTIONS = {
+    'entityTypes': [
+        {
+            'label': 'Link',
+            'type': ENTITY_TYPES.LINK,
+            'icon': 'icon-link',
+            'source': 'LinkSource',
+            'decorator': 'Link',
+        }
+    ],
+    'blockTypes': [
+        {'label': 'H1', 'type': BLOCK_TYPES.HEADER_ONE},
+        {'label': 'H2', 'type': BLOCK_TYPES.HEADER_TWO},
+        {'label': 'H3', 'type': BLOCK_TYPES.HEADER_THREE},
+    ],
+}
+
+
 class DraftailTextAreaWidgetTestCase(SimpleTestCase):
-    @unittest.expectedFailure
-    def test_rendering(self):
-        widget = DraftailTextArea()
+    def extract_options_from_script(self, script):
+        match = re.match(
+            r'window\.wagtailDraftail\.initEditor\(\'default_editor\', (\{.*\})\)$',
+            script
+        )
+        self.assertTrue(match, "Call to initEditor not found in: %r" % script)
+        return json.loads(match.group(1))
+
+    def test_rendering_with_explicit_options(self):
+        """
+        If a widget is initialised with a (populated) options dict but no
+        features list, the options dict should be passed on to the JS
+        """
+
+        widget = DraftailTextArea(options=CUSTOM_OPTIONS)
 
         html = widget.render('default_editor', json.dumps({'key': 'val'}), {'id': 'id'})
 
@@ -34,7 +65,67 @@ class DraftailTextAreaWidgetTestCase(SimpleTestCase):
             'id': 'id'
         }, soup.input.attrs)
 
-        self.assertEquals(soup.script.text, r"window.wagtailDraftail.initEditor('default_editor', {})")
+        options = self.extract_options_from_script(soup.script.text)
+        self.assertDictEqual(options, CUSTOM_OPTIONS)
+
+    def test_rendering_with_default_features(self):
+        """
+        When no options or features are specified for the widget,
+        the default feature set should be used
+        """
+
+        widget = DraftailTextArea()
+
+        html = widget.render('default_editor', json.dumps({'key': 'val'}), {'id': 'id'})
+        soup = BeautifulSoup(html, 'html.parser')
+
+        self.assertIsNotNone(soup.input)
+        self.assertIsNotNone(soup.script)
+
+        self.assertDictContainsSubset({
+            'type': 'hidden',
+            'name': 'default_editor',
+            'value': '{"key": "val"}',
+            'id': 'id'
+        }, soup.input.attrs)
+
+        options = self.extract_options_from_script(soup.script.text)
+        self.assertTrue(options['enableHorizontalRule'])
+        # default features include H3 but not H1
+        self.assertFalse([block for block in options['blockTypes'] if block['type'] == BLOCK_TYPES.HEADER_ONE])
+        self.assertTrue([block for block in options['blockTypes'] if block['type'] == BLOCK_TYPES.HEADER_THREE])
+
+        self.assertTrue([entity for entity in options['entityTypes'] if entity['type'] == ENTITY_TYPES.LINK])
+        self.assertTrue([entity for entity in options['entityTypes'] if entity['type'] == ENTITY_TYPES.IMAGE])
+
+    def test_rendering_with_explicit_features(self):
+        """
+        A features list passed to the widget should generate an options dict for those
+        features (overriding any options dict that was passed)
+        """
+
+        widget = DraftailTextArea(options=CUSTOM_OPTIONS, features=['h1', 'image'])
+
+        html = widget.render('default_editor', json.dumps({'key': 'val'}), {'id': 'id'})
+        soup = BeautifulSoup(html, 'html.parser')
+
+        self.assertIsNotNone(soup.input)
+        self.assertIsNotNone(soup.script)
+
+        self.assertDictContainsSubset({
+            'type': 'hidden',
+            'name': 'default_editor',
+            'value': '{"key": "val"}',
+            'id': 'id'
+        }, soup.input.attrs)
+
+        options = self.extract_options_from_script(soup.script.text)
+        self.assertFalse('enableHorizontalRule' in options)
+        self.assertTrue([block for block in options['blockTypes'] if block['type'] == BLOCK_TYPES.HEADER_ONE])
+        self.assertFalse([block for block in options['blockTypes'] if block['type'] == BLOCK_TYPES.HEADER_THREE])
+
+        self.assertFalse([entity for entity in options['entityTypes'] if entity['type'] == ENTITY_TYPES.LINK])
+        self.assertTrue([entity for entity in options['entityTypes'] if entity['type'] == ENTITY_TYPES.IMAGE])
 
     def test_media(self):
         widget = DraftailTextArea()

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -39,6 +39,14 @@ class DraftailTextAreaWidgetTestCase(SimpleTestCase):
         self.assertTrue(match, "Call to initEditor not found in: %r" % script)
         return json.loads(match.group(1))
 
+    def assertInOptions(self, options, typ):
+        """Assert that an entry with type `typ` exists in the given options list"""
+        self.assertTrue([i for i in options if i['type'] == typ])
+
+    def assertNotInOptions(self, options, typ):
+        """Assert that an entry with type `typ` does not exist in the given options list"""
+        self.assertFalse([i for i in options if i['type'] == typ])
+
     def test_rendering_with_explicit_options(self):
         """
         If a widget is initialised with a (populated) options dict but no
@@ -95,11 +103,11 @@ class DraftailTextAreaWidgetTestCase(SimpleTestCase):
         options = self.extract_options_from_script(soup.script.text)
         self.assertTrue(options['enableHorizontalRule'])
         # default features include H3 but not H1
-        self.assertFalse([block for block in options['blockTypes'] if block['type'] == BLOCK_TYPES.HEADER_ONE])
-        self.assertTrue([block for block in options['blockTypes'] if block['type'] == BLOCK_TYPES.HEADER_THREE])
+        self.assertNotInOptions(options['blockTypes'], BLOCK_TYPES.HEADER_ONE)
+        self.assertInOptions(options['blockTypes'], BLOCK_TYPES.HEADER_THREE)
 
-        self.assertTrue([entity for entity in options['entityTypes'] if entity['type'] == ENTITY_TYPES.LINK])
-        self.assertTrue([entity for entity in options['entityTypes'] if entity['type'] == ENTITY_TYPES.IMAGE])
+        self.assertInOptions(options['entityTypes'], ENTITY_TYPES.LINK)
+        self.assertInOptions(options['entityTypes'], ENTITY_TYPES.IMAGE)
 
     @unittest.skipIf(WAGTAIL_VERSION < (1, 12), "Rich text features are only supported on Wagtail 1.12 and above")
     def test_rendering_with_explicit_features(self):
@@ -125,11 +133,11 @@ class DraftailTextAreaWidgetTestCase(SimpleTestCase):
 
         options = self.extract_options_from_script(soup.script.text)
         self.assertFalse('enableHorizontalRule' in options)
-        self.assertTrue([block for block in options['blockTypes'] if block['type'] == BLOCK_TYPES.HEADER_ONE])
-        self.assertFalse([block for block in options['blockTypes'] if block['type'] == BLOCK_TYPES.HEADER_THREE])
+        self.assertInOptions(options['blockTypes'], BLOCK_TYPES.HEADER_ONE)
+        self.assertNotInOptions(options['blockTypes'], BLOCK_TYPES.HEADER_THREE)
 
-        self.assertFalse([entity for entity in options['entityTypes'] if entity['type'] == ENTITY_TYPES.LINK])
-        self.assertTrue([entity for entity in options['entityTypes'] if entity['type'] == ENTITY_TYPES.IMAGE])
+        self.assertNotInOptions(options['entityTypes'], ENTITY_TYPES.LINK)
+        self.assertInOptions(options['entityTypes'], ENTITY_TYPES.IMAGE)
 
     def test_media(self):
         widget = DraftailTextArea()

--- a/wagtaildraftail/blocks.py
+++ b/wagtaildraftail/blocks.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 from django.utils.encoding import force_text
 from django.utils.functional import cached_property
 
+from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.wagtailcore.blocks import RichTextBlock
 
 from wagtaildraftail.draft_text import DraftText
@@ -25,7 +26,14 @@ class DraftailTextBlock(RichTextBlock):
     @cached_property
     def field(self):
         from wagtail.wagtailadmin.rich_text import get_rich_text_editor_widget
-        return SerializedJSONField(widget=get_rich_text_editor_widget(self.editor), **self.field_options)
+        if WAGTAIL_VERSION >= (1, 12):
+            return SerializedJSONField(
+                widget=get_rich_text_editor_widget(self.editor, features=self.features), **self.field_options
+            )
+        else:
+            return SerializedJSONField(
+                widget=get_rich_text_editor_widget(self.editor), **self.field_options
+            )
 
     def to_python(self, value):
         return DraftText(value)

--- a/wagtaildraftail/features.py
+++ b/wagtaildraftail/features.py
@@ -1,0 +1,66 @@
+# Feature objects: these are mapped to feature identifiers within the rich text
+# feature registry (wagtail.wagtailcore.rich_text.features). Each one implements
+# a `construct_options` method which modifies an options dict as appropriate to
+# enable that feature.
+
+from __future__ import absolute_import, unicode_literals
+
+from draftjs_exporter.constants import ENTITY_TYPES
+
+
+class BooleanFeature(object):
+    """
+    A feature which is enabled by a boolean flag at the top level of
+    the options dict
+    """
+    def __init__(self, option_name):
+        self.option_name = option_name
+
+    def construct_options(self, options):
+        options[self.option_name] = True
+
+
+class ListFeature(object):
+    """
+    Abstract class for features that are defined in a list within the options dict.
+    Subclasses must define option_name
+    """
+    def __init__(self, data):
+        self.data = data
+
+    def construct_options(self, options):
+        if self.option_name not in options:
+            options[self.option_name] = []
+
+        options[self.option_name].append(self.data)
+
+
+class EntityFeature(ListFeature):
+    """A feature which is listed in the entityTypes list of the options"""
+    option_name = 'entityTypes'
+
+
+class BlockFeature(ListFeature):
+    """A feature which is listed in the blockTypes list of the options"""
+    option_name = 'blockTypes'
+
+
+class InlineStyleFeature(ListFeature):
+    """A feature which is listed in the inlineStyles list of the options"""
+    option_name = 'inlineStyles'
+
+
+class ImageFeature(EntityFeature):
+    """
+    Special case of EntityFeature so that we can easily define features that
+    replicate the default 'image' feature with a custom list of image formats
+    """
+    def __init__(self, image_formats='__all__'):
+        super(ImageFeature, self).__init__({
+            'label': 'Image',
+            'type': ENTITY_TYPES.IMAGE,
+            'icon': 'icon-image',
+            'imageFormats': image_formats,
+            'source': 'ImageSource',
+            'decorator': 'Image',
+        })

--- a/wagtaildraftail/fields.py
+++ b/wagtaildraftail/fields.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, unicode_literals
 from django.db import models
 from django.utils.encoding import force_text
 
+from wagtail import VERSION as WAGTAIL_VERSION
+
 from .draft_text import DraftText
 from .validators import EMPTY_SERIALIZED_JSON_VALUES
 
@@ -12,11 +14,15 @@ class DraftailTextField(models.TextField):
 
     def __init__(self, *args, **kwargs):
         self.editor = kwargs.pop('editor', 'default_draftail')
+        self.features = kwargs.pop('features', None)
         super(DraftailTextField, self).__init__(*args, **kwargs)
 
     def formfield(self, **kwargs):
         from wagtail.wagtailadmin.rich_text import get_rich_text_editor_widget
-        defaults = {'widget': get_rich_text_editor_widget(self.editor)}
+        if WAGTAIL_VERSION >= (1, 12):
+            defaults = {'widget': get_rich_text_editor_widget(self.editor, features=self.features)}
+        else:
+            defaults = {'widget': get_rich_text_editor_widget(self.editor)}
         defaults.update(kwargs)
         return super(DraftailTextField, self).formfield(**defaults)
 

--- a/wagtaildraftail/wagtail_hooks.py
+++ b/wagtaildraftail/wagtail_hooks.py
@@ -1,0 +1,91 @@
+from __future__ import absolute_import, unicode_literals
+
+from draftjs_exporter.constants import BLOCK_TYPES, ENTITY_TYPES, INLINE_STYLES
+from wagtail.wagtailcore import hooks
+
+from .features import BlockFeature, BooleanFeature, EntityFeature, ImageFeature, InlineStyleFeature
+
+
+@hooks.register('register_rich_text_features')
+def register_core_draftail_features(features):
+    features.register_editor_plugin(
+        'draftail', 'hr', BooleanFeature('enableHorizontalRule')
+    )
+
+    features.register_editor_plugin(
+        'draftail', 'br', BooleanFeature('enableLineBreak')
+    )
+
+    features.register_editor_plugin(
+        'draftail', 'h1', BlockFeature({'label': 'H1', 'type': BLOCK_TYPES.HEADER_ONE})
+    )
+    features.register_editor_plugin(
+        'draftail', 'h2', BlockFeature({'label': 'H2', 'type': BLOCK_TYPES.HEADER_TWO})
+    )
+    features.register_editor_plugin(
+        'draftail', 'h3', BlockFeature({'label': 'H3', 'type': BLOCK_TYPES.HEADER_THREE})
+    )
+    features.register_editor_plugin(
+        'draftail', 'h4', BlockFeature({'label': 'H4', 'type': BLOCK_TYPES.HEADER_FOUR})
+    )
+    features.register_editor_plugin(
+        'draftail', 'h5', BlockFeature({'label': 'H5', 'type': BLOCK_TYPES.HEADER_FIVE})
+    )
+    features.register_editor_plugin(
+        'draftail', 'h6', BlockFeature({'label': 'H6', 'type': BLOCK_TYPES.HEADER_SIX})
+    )
+    features.register_editor_plugin(
+        'draftail', 'ul', BlockFeature({
+            'label': 'UL', 'type': BLOCK_TYPES.UNORDERED_LIST_ITEM, 'icon': 'icon-list-ul'
+        })
+    )
+    features.register_editor_plugin(
+        'draftail', 'ol', BlockFeature({
+            'label': 'OL', 'type': BLOCK_TYPES.ORDERED_LIST_ITEM, 'icon': 'icon-list-ol'
+        })
+    )
+
+    features.register_editor_plugin(
+        'draftail', 'bold', InlineStyleFeature({
+            'label': 'Bold', 'type': INLINE_STYLES.BOLD, 'icon': 'icon-bold'
+        })
+    )
+    features.register_editor_plugin(
+        'draftail', 'italic', InlineStyleFeature({
+            'label': 'Italic', 'type': INLINE_STYLES.ITALIC, 'icon': 'icon-italic'
+        })
+    )
+
+    features.register_editor_plugin(
+        'draftail', 'link', EntityFeature({
+            'label': 'Link',
+            'type': ENTITY_TYPES.LINK,
+            'icon': 'icon-link',
+            'source': 'LinkSource',
+            'decorator': 'Link',
+        })
+    )
+
+    features.register_editor_plugin(
+        'draftail', 'document-link', EntityFeature({
+            'label': 'Document',
+            'type': ENTITY_TYPES.DOCUMENT,
+            'icon': 'icon-doc-full',
+            'source': 'DocumentSource',
+            'decorator': 'Document',
+        })
+    )
+
+    features.register_editor_plugin(
+        'draftail', 'image', ImageFeature()
+    )
+
+    features.register_editor_plugin(
+        'draftail', 'embed', EntityFeature({
+            'label': 'Embed',
+            'type': ENTITY_TYPES.EMBED,
+            'icon': 'icon-media',
+            'source': 'EmbedSource',
+            'decorator': 'Embed',
+        })
+    )

--- a/wagtaildraftail/widgets.py
+++ b/wagtaildraftail/widgets.py
@@ -67,7 +67,8 @@ class DraftailTextArea(WidgetWithScript, forms.HiddenInput):
         options = {}
         for feature in features:
             plugin = feature_registry.get_editor_plugin('draftail', feature)
-            plugin.construct_options(options)
+            if plugin:
+                plugin.construct_options(options)
 
         return options
 


### PR DESCRIPTION
Add support for the `features` kwarg on `DraftailTextField` and `DraftailTextBlock` (and within `WAGTAILADMIN_RICH_TEXT_EDITORS`). This was introduced on `RichTextField` and `RichTextBlock` in Wagtail 1.12 to allow [configuring the feature set of rich text fields](http://docs.wagtail.io/en/v1.12.2/advanced_topics/customisation/page_editing_interface.html#limiting-features-in-a-rich-text-field) in an editor-agnostic way, with the intention that it would allow a clean transition from Hallo.js to something better (such as Draftail :-) )